### PR TITLE
feat: Add `flake.nix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bin
 
 /pfetch
+
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729564184,
+        "narHash": "sha256-dP764PQ6YhjY7C84Txnrb2vf0H2YdQlp5c6a7G18fgw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d687672b4541496408068bc273d94c643005d4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Pixfetch";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, rust-overlay }: {
+    packages.x86_64-linux.pixfetch = nixpkgs.legacyPackages.x86_64-linux.rustPlatform.buildRustPackage {
+      pname = "pixfetch";
+      version = "1.0.0";
+      src = ./.;
+      cargoSha256 = "sha256-hLOzxfSqjelOlrF2xHBIK9ae/lgA5GrEweJzlq7Dve4=";
+    };
+
+    defaultPackage.x86_64-linux = self.packages.x86_64-linux.pixfetch;
+  };
+}


### PR DESCRIPTION
Hello,
this PR adds a `flake.nix`.
This basically allows NixOS users to build this package in a more idiomatic manner and even to install it on their system.
If you have any questions, please let me know.
Best,
Mik